### PR TITLE
Update main.v

### DIFF
--- a/main.v
+++ b/main.v
@@ -386,6 +386,9 @@ module main #(
 	reg				sync_enabled = 1'b0;
 	reg [32:0]   	sync_divide;
 	reg				sample_clk;
+	reg 				sample_clk2 = 1'b0;
+	reg 				sync1 = 1'b0;
+	reg [31:0] 		ncount = 32'b0;
 
 	// Opal Kelly USB Host Interface
 	
@@ -702,10 +705,35 @@ module main #(
 	 
 	);
 	
+
+
+	always @(posedge sample_clk) begin
+		sample_clk2 <= ~sample_clk2;
+	end
+	
+	//assign sync = sample_clk2;
+	
+	always @ (posedge sample_clk2)
+	  begin
+		 ncount <= ncount + 1;
+		 if (reset)
+			begin
+				ncount <= 0;
+				sync1 <= 1'b0;			
+			end
+		 else if (ncount > 249)
+			begin
+			sync1 <= ~ sync1;
+		   ncount <= 32'b0;
+		   end
+	  end
+	assign sync = sync1;
+	
+	
 	//Open-Ephys clock sync output
 	freqdiv #(1000) sample_clock_div(
-	 .out(sync),
-	 .clk(sample_clk),
+	 .out(open),
+	 .clk(sample_clk2),
     .reset(1'b0)
 	 );
 
@@ -962,7 +990,8 @@ module main #(
 				  ms_cs_c    = 168,
 				  ms_cs_d    = 169,
 				  ms_cs_e    = 170,
-				  ms_cs_f    = 171,
+	
+	ms_cs_f    = 171,
 				  ms_cs_g    = 172,
 				  ms_cs_h    = 173,
 				  ms_cs_i    = 174,


### PR DESCRIPTION
To get a functional sample clock divider worked into the Intan driver code, I first tried to change the code inside the freqdiv, but nothing happened and the "sync " signal was always with frequency of ~ 10MHz (with divider). Then I decided to open the net of sync from the freqdiv component and write a code in the main part "from line ~710". After some tests I found that two points should be considered in order to have a successful sync signal: 
- Do not trigger the signal on the falling edge of sample clock (I made a clock of 15KHz based on the rising edge of the signal). 
- based on the number of counter, change the sync signal. 

Another point was that I directly assigned the sync signal by assigning the sync1 register. Now it works and the clock of U20 is 30Hz with a hard-coded divide ratio of 1000.
